### PR TITLE
Fix twiglet model edit

### DIFF
--- a/src/app/twiglets/twiglet-graph/twiglet-graph.component.scss
+++ b/src/app/twiglets/twiglet-graph/twiglet-graph.component.scss
@@ -3,6 +3,7 @@
 :host {
   display: flex;
   flex: 1;
+  position: relative;
 
   svg {
     cursor: default;

--- a/src/app/twiglets/twiglet-home/twiglet-home.component.html
+++ b/src/app/twiglets/twiglet-home/twiglet-home.component.html
@@ -14,6 +14,6 @@
       [twigletModel]="twigletModel"
       (addEntity)="addEntity($event)"
   ></app-header-twiglet>
-  <app-twiglet-graph [class]="getTwigletGraphClass()" boundSensor="resize"></app-twiglet-graph>
+  <app-twiglet-graph [class]="getTwigletGraphClass()" [boundSensor]="{eventName: 'resize', modifyStyles: false}"></app-twiglet-graph>
   <app-twiglet-model-view [class]="getTwigletModelClass()" #modelEditor ></app-twiglet-model-view>
 </div>

--- a/src/app/twiglets/twiglet-home/twiglet-home.component.spec.ts
+++ b/src/app/twiglets/twiglet-home/twiglet-home.component.spec.ts
@@ -1,4 +1,5 @@
 import { ViewDropdownComponent } from './../view-dropdown/view-dropdown.component';
+import { BoundSensorModule } from 'angular-bound-sensor';
 import { BreadcrumbNavigationComponent } from './../breadcrumb-navigation/breadcrumb-navigation.component';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
@@ -44,6 +45,7 @@ describe('TwigletHomeComponent', () => {
         ViewDropdownComponent
       ],
       imports: [
+        BoundSensorModule,
         DismissibleHelpModule,
         DragulaModule,
         NgbModule.forRoot(),


### PR DESCRIPTION
The angular-bound-sensor module was overriding our styles, which is why the twiglet graph didn't disappear when editing a model. Just had to flag it with modifyStyles: false.