### PR TITLE
changing output artifact to entire src directory

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,8 @@ version: 0.1
 phases:
   install:
     commands:
+      - mkdir /tmp/tmpsrc
+      - cp -r . /tmp/tmpsrc
       - apt-get update
       - apt-get -y install curl
       - curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
@@ -21,6 +23,7 @@ phases:
       - cat /tmp/build_id.out
       - cat /tmp/build_tag.out
       - cat /tmp/build.json
+      - cp /tmp/build.json /tmp/tmpsrc
       - $(aws ecr get-login --region ${AWS_REGION} --no-include-email)
   build:
     commands:
@@ -34,6 +37,9 @@ phases:
       - aws s3 cp --recursive --quiet --acl public-read ./reports ${REPORTS_BUCKET}
       - aws s3 cp --recursive --quiet --acl public-read ./coverage ${REPORTS_BUCKET}/coverage
       - docker push "$(cat /tmp/build_tag.out)"
+      - mv /tmp/tmpsrc/ .
+      - ls -la tmpsrc
 artifacts:
-  files: /tmp/build.json
-  discard-paths: yes
+  files:
+   - '**/*'
+  base-directory: 'tmpsrc'


### PR DESCRIPTION
This puts the build.json into the buildsrc, so that the deploy pipeline is only triggered once.